### PR TITLE
different scroll container (target) than html, body

### DIFF
--- a/jquery.scrollify.js
+++ b/jquery.scrollify.js
@@ -58,7 +58,6 @@ if touchScroll is false - update index
     timeoutId2,
     $window = $(window),
     portHeight,
-    top = $window.scrollTop(),
     scrollable = false,
     locked = false,
     scrolled = false,
@@ -92,9 +91,10 @@ if touchScroll is false - update index
       after:function() {},
       afterResize:function() {},
       afterRender:function() {}
-    };
+    },
+    top = $(settings.target).scrollTop();
   function getportHeight() {
-    return (window.innerHeight + settings.offset);
+    return ($(settings.target).innerHeight() + settings.offset);
   }
   function animateScroll(index,instant,callbacks,toTop) {
     if(currentIndex===index) {
@@ -248,7 +248,7 @@ if touchScroll is false - update index
         }, 200);
       },
       calculateNearest:function(instant,callbacks) {
-        top = $window.scrollTop();
+        top = $(settings.target).scrollTop();
         var i =1,
           max = heights.length,
           closest = 0,
@@ -596,7 +596,7 @@ if touchScroll is false - update index
 
     function sizePanels(keepPosition) {
       if(keepPosition) {
-        top = $window.scrollTop();
+        top = $(settings.target).scrollTop();
       }
 
       var selector = settings.section;
@@ -642,7 +642,7 @@ if touchScroll is false - update index
         }
       });
       if(keepPosition) {
-        $window.scrollTop(top);
+        $(settings.target).scrollTop(top);
       }
     }
     function calculatePositions(scroll,firstLoad) {
@@ -696,7 +696,7 @@ if touchScroll is false - update index
       if(!overflow[index]) {
         return true;
       }
-      top = $window.scrollTop();
+      top = $(settings.target).scrollTop();
       if(top>parseInt(heights[index])) {
         return false;
       } else {
@@ -707,7 +707,7 @@ if touchScroll is false - update index
       if(!overflow[index]) {
         return true;
       }
-      top = $window.scrollTop();
+      top = $(settings.target).scrollTop();
       portHeight = getportHeight();
 
       if(top<parseInt(heights[index])+(elements[index].outerHeight()-portHeight)-28) {


### PR DESCRIPTION
Fixed this for my mdc theme which uses a div (#main-content) as scroll container while activated navigation drawer.
https://material.io/components/navigation-drawer

Usage example:

      $.scrollify({
        section : "article.post, .site-footer", // add .site-footer to reach bottom
        scrollSpeed: 200,
        setHeights: false,
        target:"#main-content" 
      });